### PR TITLE
feat: add micro program crawler

### DIFF
--- a/.github/workflows/fetchCurrentMPrograms.yaml
+++ b/.github/workflows/fetchCurrentMPrograms.yaml
@@ -1,0 +1,28 @@
+name: fetch current mprograms
+
+on:
+  push:
+    branches:
+      - 蹦蹦
+  schedule:
+    - cron: "0 0 */1 * *"
+
+jobs:
+  FetchMProgram:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Install npm packages
+        run: npm install
+      - name: Fetch micro program data
+        run: node fetchMProgram.js
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ https://ntut-course.gnehs.net/api
 - clone repo
 - `cd ./path/ntut-course-crawler-node`
 - `npm i`
-- `node fetchAll.js` or `node fetchCourse.js`
+- `node fetchAll.js`
+- `node fetchCourse.js`
+- `node fetchMProgram.js`
 
 ## 提醒
 - 課程網站若抓取過快很容易被封鎖，因此本爬蟲有限制同一時間抓取頁面數量，可自行調整。

--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -1,0 +1,49 @@
+const { fetchSinglePage } = require("./fetchSinglePage");
+const jsonfile = require("jsonfile");
+const fs = require("fs");
+const pangu = require("./tools/pangu").spacing;
+
+const globalRegexParse = /\n|^ | $/g;
+
+async function fetchProgramCourse(href) {
+  const url = "https://aps.ntut.edu.tw/course/tw/" + href;
+  const $ = await fetchSinglePage(url);
+  $("tr:first-child").remove();
+  $("tr:last-child").remove();
+  const courses = [];
+  for (const tr of $("tr")) {
+    const id = $($(tr).children("td")[0]).text().replace(globalRegexParse, "");
+    const nameLink = $($(tr).children("td")[1]).find("a");
+    if (!id || !nameLink.length) continue;
+    courses.push({
+      id,
+      name: pangu(nameLink.text().replace(globalRegexParse, "")),
+      href: nameLink.attr("href"),
+    });
+  }
+  return courses;
+}
+
+async function fetchMProgram(year = 110, sem = 2) {
+  console.log("[fetch] 正在取得微學程列表...");
+  const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
+  const $ = await fetchSinglePage(url);
+  const programs = $("a[href^='SearchMProgram.jsp?format=-2']");
+  const res = [];
+  let progress = 0;
+  for (const program of programs) {
+    const name = pangu($(program).text());
+    const href = $(program).attr("href");
+    progress++;
+    console.log(`[fetch] 正在取得 (${progress}/${programs.length}) ${name}`);
+    const course = await fetchProgramCourse(href);
+    res.push({ name, href, course });
+  }
+  fs.mkdirSync(`./dist/${year}/${sem}/`, { recursive: true });
+  jsonfile.writeFileSync(`./dist/${year}/${sem}/mprogram.json`, res, {
+    spaces: 2,
+    EOL: "\r\n",
+  });
+}
+
+module.exports = { fetchMProgram };

--- a/fetchAll.js
+++ b/fetchAll.js
@@ -1,6 +1,7 @@
 const fetchYearSem = require("./crawler/fetchYearSem");
 const { fetchCourse } = require("./crawler/fetchCourse");
 const { fetchDepartment } = require("./crawler/fetchDepartment");
+const { fetchMProgram } = require("./crawler/fetchMProgram");
 
 (async () => {
   let { years } = await fetchYearSem();
@@ -8,6 +9,7 @@ const { fetchDepartment } = require("./crawler/fetchDepartment");
     for (let sem of years[year]) {
       await Promise.all([
         fetchDepartment(year, sem),
+        fetchMProgram(year, sem),
         fetchCourse("日間部", year, sem),
         fetchCourse("進修部", year, sem),
         fetchCourse("研究所(日間部、進修部、週末碩士班)", year, sem),

--- a/fetchMProgram.js
+++ b/fetchMProgram.js
@@ -1,0 +1,15 @@
+// node fetchMProgram.js <year> <sem>
+const fetchYearSem = require("./crawler/fetchYearSem");
+const { fetchMProgram } = require("./crawler/fetchMProgram");
+
+(async () => {
+  let year = process.argv[2] || null,
+    sem = process.argv[3] || null;
+  if (!year || !sem) {
+    let { current } = await fetchYearSem();
+    year = current.year;
+    sem = current.sem;
+  }
+  await fetchMProgram(year, sem);
+  console.log("All done!");
+})();


### PR DESCRIPTION
## Summary
- add crawler for micro program listing and courses
- expose fetchMProgram script and integrate with fetchAll
- document micro program fetch command
- schedule micro program data fetch via GitHub Actions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `timeout 20 node fetchMProgram.js 114 1` *(no response, command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68c06c4528a0833181f90241f684645d