### PR TITLE
Fix micro program scraping to treat each program as class

### DIFF
--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -1,3 +1,4 @@
+const cheerio = require("cheerio");
 const { fetchSinglePage } = require("./fetchSinglePage");
 const jsonfile = require("jsonfile");
 const fs = require("fs");
@@ -5,39 +6,48 @@ const pangu = require("./tools/pangu").spacing;
 
 const globalRegexParse = /\n|^ | $/g;
 
-async function fetchProgramCourse(href) {
-  const url = "https://aps.ntut.edu.tw/course/tw/" + href;
-  const $ = await fetchSinglePage(url);
+async function fetchProgramCourse(href, page) {
+  let $;
+  if (page) {
+    $ = typeof page === "string" ? cheerio.load(page) : page;
+  } else {
+    const url = "https://aps.ntut.edu.tw/course/tw/" + href;
+    $ = await fetchSinglePage(url);
+  }
   $("tr:first-child").remove();
-  $("tr:last-child").remove();
   const courses = [];
   for (const tr of $("tr")) {
-    const id = $($(tr).children("td")[0]).text().replace(globalRegexParse, "");
-    const nameLink = $($(tr).children("td")[1]).find("a");
-    if (!id || !nameLink.length) continue;
-    courses.push({
-      id,
-      name: pangu(nameLink.text().replace(globalRegexParse, "")),
-      href: nameLink.attr("href"),
-    });
+    const id = $(tr)
+      .children("td")
+      .first()
+      .text()
+      .replace(globalRegexParse, "");
+    if (id) courses.push(id);
   }
   return courses;
 }
 
-async function fetchMProgram(year = 110, sem = 2) {
+async function fetchMProgram(year = 110, sem = 2, listPage = null, programPages = {}) {
   console.log("[fetch] 正在取得微學程列表...");
-  const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
-  const $ = await fetchSinglePage(url);
+  let $;
+  if (listPage) {
+    $ = typeof listPage === "string" ? cheerio.load(listPage) : listPage;
+  } else {
+    const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
+    $ = await fetchSinglePage(url);
+  }
   const programs = $("a[href^='SearchMProgram.jsp?format=-2']");
   const res = [];
   let progress = 0;
   for (const program of programs) {
     const name = pangu($(program).text());
     const href = $(program).attr("href");
+    const urlParser = new URL("https://aps.ntut.edu.tw/course/tw/" + href);
+    const id = urlParser.searchParams.get("code");
     progress++;
     console.log(`[fetch] 正在取得 (${progress}/${programs.length}) ${name}`);
-    const course = await fetchProgramCourse(href);
-    res.push({ name, href, course });
+    const course = await fetchProgramCourse(href, programPages[id]);
+    res.push({ id, name, href, course });
   }
   fs.mkdirSync(`./dist/${year}/${sem}/`, { recursive: true });
   jsonfile.writeFileSync(`./dist/${year}/${sem}/mprogram.json`, res, {


### PR DESCRIPTION
## Summary
- Allow micro program scraper to load pre-fetched HTML for offline parsing
- Extract only course identifiers for each micro program

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c499bdb0a88331821f2792c164d649