### PR TITLE
Fix microprogram parsing capturing schedule times

### DIFF
--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -14,9 +14,10 @@ async function fetchProgramCourse(href, page) {
     const url = "https://aps.ntut.edu.tw/course/tw/" + href;
     $ = await fetchSinglePage(url);
   }
-  $("tr:first-child").remove();
+  const table = $("table").first();
+  const rows = table.find("tr").slice(1);
   const courses = [];
-  for (const tr of $("tr")) {
+  for (const tr of rows) {
     const id = $(tr)
       .children("td")
       .first()


### PR DESCRIPTION
## Summary
- limit microprogram course scraping to the first table to avoid parsing schedule time rows

## Testing
- `npm test` (fails: no test specified)
- `node -e "..."` on sample HTML to ensure only course IDs are returned

------
https://chatgpt.com/codex/tasks/task_e_68c4ae84195c8331b54bcdc9844e42a1